### PR TITLE
upgrade to latest rhino package

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -23,8 +23,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.mozilla</groupId>
-			<artifactId>javascript</artifactId>
-			<version>1.6R5</version>
+			<artifactId>rhino</artifactId>
+			<version>1.7.7.1</version>
 		</dependency>
 		<dependency>
 			<groupId>net.sf.transmorph</groupId>


### PR DESCRIPTION
Hi Tango-team,

the package `org.mozilla.javascript` seems not to be provided anymore on http://central.maven.org as artifact `javascript` in group `org.mozilla`. I guess it has been moved into artifact `rhino` in group `org.mozilla`, see https://mvnrepository.com/artifact/rhino/js