### PR TITLE
Fix a NPE when cache is unavailable. Start polling on dynamic attribute event if created after initDevice()

### DIFF
--- a/server/src/main/java/org/tango/server/cache/PollingManager.java
+++ b/server/src/main/java/org/tango/server/cache/PollingManager.java
@@ -366,7 +366,7 @@ public final class PollingManager {
             final Element element = cacheManager.getCommandCache(cmd).get(cmd.getName().toLowerCase(Locale.ENGLISH));
             final Serializable cmdValue = element.getValue();
             if (cmdValue instanceof org.tango.server.attribute.AttributeValue) {
-                // state or status are returned as attributevalue
+                // state or status are returned as attribute value
                 ret = ((org.tango.server.attribute.AttributeValue) cmdValue).getValue();
             } else {
                 ret = element.getValue();

--- a/server/src/main/java/org/tango/server/cache/TangoCacheManager.java
+++ b/server/src/main/java/org/tango/server/cache/TangoCacheManager.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import javax.management.MBeanServer;
 
+import net.sf.ehcache.CacheException;
 import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.config.CacheConfiguration;
 import net.sf.ehcache.config.Configuration;
@@ -400,6 +401,8 @@ public final class TangoCacheManager {
             AttributeCache attrCache = attributeCacheMap.get(attr);
             if (attrCache == null) {
                 attrCache = extTrigAttributeCacheMap.get(attr);
+                if (attrCache == null)
+                    throw new CacheException("No cache found for " + attr.getName());
             }
             cache = attrCache.getCache();
         }

--- a/server/src/main/java/org/tango/server/dynamic/DynamicManager.java
+++ b/server/src/main/java/org/tango/server/dynamic/DynamicManager.java
@@ -95,7 +95,8 @@ public final class DynamicManager {
      * @throws DevFailed
      */
     public void addAttribute(final IAttributeBehavior behavior) throws DevFailed {
-        final String attributeName = behavior.getConfiguration().getName();
+        final AttributeConfiguration configuration = behavior.getConfiguration();
+        final String attributeName = configuration.getName();
         xlogger.entry("adding dynamic attribute {}", attributeName);
         if (behavior instanceof ForwardedAttribute) {
             // init attribute with either the attribute property value, or the value defined in its constructor
@@ -123,13 +124,12 @@ public final class DynamicManager {
             }
         } else {
             // set default properties
-            final AttributeConfiguration config = behavior.getConfiguration();
-            final AttributePropertiesImpl prop = config.getAttributeProperties();
+            final AttributePropertiesImpl prop = configuration.getAttributeProperties();
             if (prop.getLabel().isEmpty()) {
-                prop.setLabel(config.getName());
+                prop.setLabel(configuration.getName());
             }
             if (prop.getFormat().equals(Constants.NOT_SPECIFIED)) {
-                prop.setDefaultFormat(config.getScalarType());
+                prop.setDefaultFormat(configuration.getScalarType());
             }
         }
         final AttributeImpl attrImpl = new AttributeImpl(behavior, deviceImpl.getName());
@@ -137,6 +137,9 @@ public final class DynamicManager {
         deviceImpl.addAttribute(attrImpl);
         dynamicAttributes.put(attributeName.toLowerCase(Locale.ENGLISH), attrImpl);
         deviceImpl.pushInterfaceChangeEvent(false);
+        if (configuration.isPolled() && configuration.getPollingPeriod()>0) {
+            deviceImpl.addAttributePolling(attributeName, configuration.getPollingPeriod());
+        }
         xlogger.exit();
     }
 

--- a/server/src/main/java/org/tango/server/servant/AttributeGetterSetter.java
+++ b/server/src/main/java/org/tango/server/servant/AttributeGetterSetter.java
@@ -231,6 +231,10 @@ public final class AttributeGetterSetter {
                 if (e.getCause() instanceof DevFailed) {
                     back[i] = TangoIDLAttributeUtil.toAttributeValue5Error(names[i], AttrDataFormat.FMT_UNKNOWN, 0,
                             (DevFailed) e.getCause());
+                } else {
+                    back[i] = TangoIDLAttributeUtil.toAttributeValue5Error(names[i], att.getFormat(),
+                            att.getTangoType(),
+                            DevFailedUtils.newDevFailed("CACHE_ERROR", names[i] + " not available from cache"));
                 }
             }
             // aroundInvoke.aroundInvoke(new InvocationContext(ContextType.POST_READ_ATTRIBUTE, callType,


### PR DESCRIPTION
Fix a NPE when cache is unavailable.
Start polling on dynamic attribute event if created after initDevice()