### PR TITLE
fix typo in the CtrlSystem/EventBufferHwm error message

### DIFF
--- a/server/src/main/java/org/tango/server/events/EventManager.java
+++ b/server/src/main/java/org/tango/server/events/EventManager.java
@@ -106,7 +106,7 @@ public final class EventManager {
         } catch (final DevFailed e) {
             DevFailedUtils.logDevFailed(e, logger);
         } catch (final NumberFormatException e) {
-            logger.error("ControlSystem/EventBufferHwm property is not a number: {} ", value);
+            logger.error("CtrlSystem/EventBufferHwm property is not a number: {} ", value);
         }
 
         isInitialized = false;


### PR DESCRIPTION
The current error message is really misleading.  one has to look at the code in order to find that missing property is `CtrlSystem/EventBufferHwm` instead of  `ControlSystem/EventBufferHwm`