### PR TITLE
Enable sources and java doc generation when deploying artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
         - cd parent
         - mvn versions:set versions:update-child-modules -DnewVersion=${TRAVIS_BRANCH} -DprocessAllModule -DgenerateBackupPoms=false
         - cd ..
-        - mvn install -Dmaven.test.skip=true
+        - mvn install -Dmaven.test.skip=true -Prelease
       deploy:
         - provider: script
           script: bash .travis/maven_deploy.sh


### PR DESCRIPTION
Javadic and sources jars are missing in bintray. This should fix it. We will need to make a new release after this PR has been merged.