### PR TITLE
Enable sources and javadoc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
         - cd parent
         - mvn versions:set versions:update-child-modules -DnewVersion=${TRAVIS_BRANCH} -DprocessAllModule -DgenerateBackupPoms=false
         - cd ..
-        - mvn install -Dmaven.test.skip=true -Prelease
+        - mvn install -Dmaven.test.skip=true
       deploy:
         - provider: script
           script: bash .travis/maven_deploy.sh

--- a/.travis/maven_deploy.sh
+++ b/.travis/maven_deploy.sh
@@ -4,7 +4,7 @@ set -e
 
 cp .travis/settings.xml $HOME/.m2/settings.xml
 
-mvn deploy -Dmaven.test.skip=true
+mvn deploy -Dmaven.test.skip=true -Prelease
 
 cd parent
 mvn versions:set versions:update-child-modules -DprocessAllModules -DnextSnapshot -DgenerateBackupPoms=false


### PR DESCRIPTION
Javadoc and sources jars are missing in bintray. This should fix it. We will need to make a new release after this PR has been merged.

This fixes #82 which was accidentally merged in `jtango-9-lts` by travis