### PR TITLE
Vectors refactoring in Group package (GroupAttrReplyList/GroupCmdReplyList/GroupReplyList)

### DIFF
--- a/common/src/main/java/fr/esrf/TangoApi/Group/GroupAttrReplyList.java
+++ b/common/src/main/java/fr/esrf/TangoApi/Group/GroupAttrReplyList.java
@@ -35,13 +35,13 @@
 package fr.esrf.TangoApi.Group;
 
 //- Import Java stuffs
-import java.util.Vector;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * TANGO group reply for attribute read/write operations
  */
 
-public class GroupAttrReplyList extends Vector implements java.io.Serializable {
+public class GroupAttrReplyList extends CopyOnWriteArrayList<GroupAttrReply> implements java.io.Serializable {
 
     /**
      * Global error flag
@@ -54,12 +54,9 @@ public class GroupAttrReplyList extends Vector implements java.io.Serializable {
     }
     
     /** Adds an element to the list */
-    public boolean add(Object o) {
-        if (o instanceof GroupAttrReply == false) {
-            return true;
-        }
-        GroupAttrReply gcr = (GroupAttrReply)o;
-        if (gcr.has_failed) {
+    @Override
+    public boolean add(GroupAttrReply o) {
+        if (o.has_failed) {
             has_failed = true;
         }
         return super.add(o);
@@ -67,7 +64,7 @@ public class GroupAttrReplyList extends Vector implements java.io.Serializable {
     
     /** Resets error flag and clears the list */
     public void reset() {
-        removeAllElements();
+        clear();
         has_failed = false;
     }
     

--- a/common/src/main/java/fr/esrf/TangoApi/Group/GroupCmdReplyList.java
+++ b/common/src/main/java/fr/esrf/TangoApi/Group/GroupCmdReplyList.java
@@ -35,12 +35,14 @@
 package fr.esrf.TangoApi.Group;
 
 //- Import Java stuffs
-import java.util.Vector;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * TANGO group reply list for command
  */
-public class GroupCmdReplyList extends Vector implements java.io.Serializable {
+public class GroupCmdReplyList extends CopyOnWriteArrayList<GroupCmdReply> implements java.io.Serializable {
 
     /**
      * Global error flag
@@ -51,14 +53,15 @@ public class GroupCmdReplyList extends Vector implements java.io.Serializable {
     public GroupCmdReplyList() {
         has_failed = false;
     }
-    
+
+    public Enumeration<GroupCmdReply> elements() {
+        return Collections.enumeration(this);
+    }
+
     /** Adds an element to the list */
-    public boolean add(Object o) {
-        if (o instanceof GroupCmdReply == false) {
-            return true;
-        }
-        GroupCmdReply gcr = (GroupCmdReply)o;
-        if (gcr.has_failed) {
+    @Override
+    public boolean add(GroupCmdReply o) {
+        if (o.has_failed) {
             has_failed = true;
         }
         return super.add(o);
@@ -66,7 +69,7 @@ public class GroupCmdReplyList extends Vector implements java.io.Serializable {
     
     /** Resets error flag and clears the list */
     public void reset() {
-        removeAllElements();
+        clear();
         has_failed = false;
     }
     

--- a/common/src/main/java/fr/esrf/TangoApi/Group/GroupReplyList.java
+++ b/common/src/main/java/fr/esrf/TangoApi/Group/GroupReplyList.java
@@ -35,13 +35,13 @@
 package fr.esrf.TangoApi.Group;
 
 //- Import Java stuffs
-import java.util.Vector;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * TANGO group reply for attribute read/write operations
  */
 
-public class GroupReplyList extends Vector implements java.io.Serializable {
+public class GroupReplyList extends CopyOnWriteArrayList<GroupReply> implements java.io.Serializable {
 
     /**
      * Global error flag
@@ -54,12 +54,9 @@ public class GroupReplyList extends Vector implements java.io.Serializable {
     }
     
     /** Adds an element to the list */
-    public boolean add(Object o) {
-        if (o instanceof GroupReply == false) {
-            return true;
-        }
-        GroupReply gcr = (GroupReply)o;
-        if (gcr.has_failed) {
+    @Override
+    public boolean add(GroupReply o) {
+        if (o.has_failed) {
             has_failed = true;
         }
         return super.add(o);
@@ -67,7 +64,7 @@ public class GroupReplyList extends Vector implements java.io.Serializable {
     
     /** Resets error flag and clears the list */
     public void reset() {
-        removeAllElements();
+        clear();
         has_failed = false;
     }
     

--- a/common/src/test/java/fr/esrf/TangoApi/Group/CollectionTestHelper.java
+++ b/common/src/test/java/fr/esrf/TangoApi/Group/CollectionTestHelper.java
@@ -1,0 +1,48 @@
+package fr.esrf.TangoApi.Group;
+
+import org.junit.Assert;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public abstract class CollectionTestHelper<T extends CopyOnWriteArrayList<S>, S extends GroupReply> {
+
+    private final Class<T> collectionClass;
+    protected T collection;
+
+    public CollectionTestHelper(Class<T> collectionClass) {
+        this.collectionClass = collectionClass;
+    }
+
+    protected void setup(String... args) throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+        collection = collectionClass.getConstructor().newInstance();
+        if (args.length % 2 != 0) {
+            System.out.println("The args length must be even number");
+            return;
+        }
+
+        for (int i = 0; i < args.length; i += 2) {
+            collection.add(create(args[i], args[i + 1]));
+        }
+    }
+
+    protected void doTestRead(int tabLength) {
+        for (int i = 0; i < tabLength; i++) {
+            S reply = collection.get(i);
+            Assert.assertNotNull(reply);
+        }
+    }
+
+    protected S doTestAdd(String devName, String objName) {
+        collection.add(create(devName, objName));
+        S reply = collection.get(collection.size() - 1);
+
+        Assert.assertEquals(devName, reply.dev_name);
+        Assert.assertEquals(objName, reply.obj_name);
+        Assert.assertTrue(reply.has_failed);
+
+        return reply;
+    }
+
+    protected abstract S create(String devName, String objName);
+}

--- a/common/src/test/java/fr/esrf/TangoApi/Group/GroupAttrReplyTest.java
+++ b/common/src/test/java/fr/esrf/TangoApi/Group/GroupAttrReplyTest.java
@@ -1,0 +1,46 @@
+package fr.esrf.TangoApi.Group;
+
+import fr.esrf.Tango.DevFailed;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class GroupAttrReplyTest extends CollectionTestHelper<GroupAttrReplyList, GroupAttrReply> {
+
+    public GroupAttrReplyTest() {
+        super(GroupAttrReplyList.class);
+    }
+
+    @Before
+    public void setup() throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
+        setup("testDevice1", "testAttr1", "testDevice2", "testAttr2");
+    }
+
+    @Test
+    public void readGroupAttReplyTest() {
+        doTestRead(2);
+        Assert.assertEquals(2, collection.size());
+    }
+
+    @Test
+    public void addGroupAttReplyTest() {
+        GroupAttrReply groupAttrReply = doTestAdd("testDevice3", "newAtt");
+        Assert.assertThrows(DevFailed.class, groupAttrReply::get_data);
+
+        Assert.assertEquals(3, collection.size());
+    }
+
+    @Test
+    public void resetGroupAttReplyTest() {
+        collection.reset();
+        Assert.assertEquals(0, collection.size());
+        Assert.assertFalse(collection.has_failed);
+    }
+
+    @Override
+    protected GroupAttrReply create(String devName, String attrName) {
+        return new GroupAttrReply(devName, attrName, new DevFailed());
+    }
+}

--- a/common/src/test/java/fr/esrf/TangoApi/Group/GroupCmdReplyListTest.java
+++ b/common/src/test/java/fr/esrf/TangoApi/Group/GroupCmdReplyListTest.java
@@ -1,0 +1,45 @@
+package fr.esrf.TangoApi.Group;
+
+import fr.esrf.Tango.DevFailed;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class GroupCmdReplyListTest extends CollectionTestHelper<GroupCmdReplyList, GroupCmdReply> {
+
+    public GroupCmdReplyListTest() {
+        super(GroupCmdReplyList.class);
+    }
+
+    @Before
+    public void setup() throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
+        setup("testDevice1", "testCommand1", "testDevice2", "testCommand2");
+    }
+
+    @Test
+    public void readGroupCmdReplyTest() {
+        doTestRead(2);
+        Assert.assertEquals(2, collection.size());
+    }
+
+    @Test
+    public void addGroupCmdReplyTest() {
+        GroupCmdReply groupCmdReply = doTestAdd("testDevice3", "newAtt");
+        Assert.assertThrows(DevFailed.class, groupCmdReply::get_data);
+    }
+
+    @Test
+    public void resetGroupCmdReplyTest() {
+        collection.reset();
+        Assert.assertEquals(0, collection.size());
+        Assert.assertFalse(collection.has_failed);
+    }
+
+    @Override
+    protected GroupCmdReply create(String devName, String commandName) {
+        return new GroupCmdReply(devName, commandName, new DevFailed());
+    }
+
+}

--- a/common/src/test/java/fr/esrf/TangoApi/Group/GroupReplyListTest.java
+++ b/common/src/test/java/fr/esrf/TangoApi/Group/GroupReplyListTest.java
@@ -1,0 +1,44 @@
+package fr.esrf.TangoApi.Group;
+
+import fr.esrf.Tango.DevFailed;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class GroupReplyListTest extends CollectionTestHelper<GroupReplyList, GroupReply> {
+
+    public GroupReplyListTest() {
+        super(GroupReplyList.class);
+    }
+
+    @Before
+    public void setup() throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
+        setup("testDevice1", "testAttr1", "testDevice2", "testAttr2");
+    }
+
+    @Test
+    public void readGroupReplyTest() {
+        doTestRead(2);
+        Assert.assertEquals(2, collection.size());
+    }
+
+    @Test
+    public void addGroupReplyTest() {
+        doTestAdd("testDevice3", "newCommand");
+        Assert.assertEquals(3, collection.size());
+    }
+
+    @Test
+    public void resetGroupReplyTest() {
+        collection.reset();
+        Assert.assertEquals(0, collection.size());
+        Assert.assertFalse(collection.has_failed);
+    }
+
+    @Override
+    protected GroupReply create(String devName, String objName) {
+        return new GroupReply(devName, objName, new DevFailed());
+    }
+}


### PR DESCRIPTION
- Convert GroupAttrReplyList/GroupCmdReplyList/GroupReplyList to use CopyOnWriteArrayList instead Vector.

- Also increases test coverage for this class.